### PR TITLE
 - Kommasetzung Grußformel korrigiert

### DIFF
--- a/_data.tex
+++ b/_data.tex
@@ -8,7 +8,7 @@ hiermit die Rechnung. Bitte zahlen Sie den unten aufgeführten Gesamtbetrag
 unter Angabe der Rechnungsnummer (\invoiceReference) bis
 zum \payDate \ auf das angegebene Konto ein.} % Rechnungstext
 \newcommand{\invoiceEnclosures}{} % \encl{} einfügen
-\newcommand{\invoiceClosing}{Mit freundlichen Grüßen,}
+\newcommand{\invoiceClosing}{Mit freundlichen Grüßen}
 % ################## invoice DATA ##################
 
 


### PR DESCRIPTION
Moin,

im Deutschen steht nach der Grußformel kein Komma - entfernt. Bitte übernehmen, damit es für alle korrekt ist :)

http://www.neue-rechtschreibung.net/2009/05/22/kein-komma-nach-grusformel/

Grüße
Matthias