### PR TITLE
typo

### DIFF
--- a/_data.tex
+++ b/_data.tex
@@ -3,7 +3,7 @@
 \newcommand{\payDate}{DD.MM.YYYY} % Datum der Zahlungsfrist
 \newcommand{\invoiceReference}{YYYYMMDD-1} % Rechnungsnummer (z.B. 20150122-4)
 \newcommand{\invoiceSalutation}{Sehr geehrte Damen und Herren,} % die Anrede
-\newcommand{\invoiceText}{Für die von mir erbrachte Leistung erhalten sie
+\newcommand{\invoiceText}{Für die von mir erbrachte Leistung erhalten Sie
 hiermit die Rechnung. Bitte zahlen Sie den unten aufgeführten Gesamtbetrag
 unter Angabe der Rechnungsnummer (\invoiceReference) bis
 zum \payDate \ auf das angegebene Konto ein.} % Rechnungstext


### PR DESCRIPTION
"Sie" is spelled with capital S in a german letter if it is the polite form of address.