### PR TITLE
fixed bug where the discount rounding is done wrong

### DIFF
--- a/invoice.sty
+++ b/invoice.sty
@@ -795,7 +795,7 @@
 	%			and amount of discount
 	%
 	\gdef\Discount@Contents{#1}%
-	\setcounter{Discount}{100 * \real{-#2}}%
+	\setcounter{Discount}{(1000 * \real{-#2} - 5) / 10}%
 }%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newcommand{\Total@Reset}{%


### PR DESCRIPTION
There was a bug where if the discount was x.89 it would show as n.89 and also be calculated wrong. This fixes the bug. The calc bib is always rounding down so this is working in all cases